### PR TITLE
Running pytest as part of CI/github actions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -27,6 +27,24 @@ jobs:
       - name: Update qualibrate-core to latest main
         run: poetry update qualibrate-core
 
+      - name: Create qualibrate config for tests
+        run: |
+          mkdir -p ~/.qualibrate
+          cat > ~/.qualibrate/config.toml << 'EOF'
+          [qualibrate]
+          version = 5
+          project = "test"
+          log_folder = "/tmp/qualibrate/logs"
+
+          [qualibrate.storage]
+          type = "local_storage"
+          location = "/tmp/qualibrate/data"
+
+          [qualibrate.calibration_library]
+          folder = "/tmp/qualibrate/calibrations"
+          resolver = "qualibrate.QualibrationLibrary"
+          EOF
+
       - name: Check python package typing
         run: poetry run poe type
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -24,6 +24,9 @@ jobs:
       - name: Install python deps
         run: poetry install --with dev
 
+      - name: Update qualibrate-core to latest main
+        run: poetry update qualibrate-core
+
       - name: Check python package typing
         run: poetry run poe type
 
@@ -32,3 +35,6 @@ jobs:
 
       - name: Check format python package
         run: poetry run poe format
+
+      - name: Run tests
+        run: poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -3090,7 +3090,7 @@ types-networkx = "~3.4.2.20250527"
 type = "git"
 url = "https://github.com/qua-platform/qualibrate-core.git"
 reference = "HEAD"
-resolved_reference = "e02b120503bdeccf0579ef406ece2c2cc48f36d0"
+resolved_reference = "6d9eed5a7fa0073131b00b4405a33b5c75289a93"
 
 [[package]]
 name = "quam"


### PR DESCRIPTION
- Add poetry update qualibrate-core step to fetch the latest main branch before running checks
- Add pytest step to run tests in CI
This ensures CI always tests against the latest qualibrate-core rather than the version locked in poetry.lock.
